### PR TITLE
Put back deleted parenthesis

### DIFF
--- a/FileService.cpp
+++ b/FileService.cpp
@@ -30,7 +30,7 @@ FileService::~FileService() {
 
 bool FileService::endswith(string str, string suffix) {
   size_t pos = str.rfind(suffix);
-  return pos == str.length() - suffix.length() ;
+  return pos == (str.length() - suffix.length());
 }
 
 void FileService::get(HTTPRequest *request, HTTPResponse *response) {


### PR DESCRIPTION
I accidentally deleted these parenthesis when I made the [PR](https://github.com/kingst/gunrock_web/pull/5/files#diff-ad97b9e7a85792af56c3d697ab55268dd9cd48ca05cc512ab310f68ae3f8c3f6L33) so just want to put them back to maintain consistency with the code styling.